### PR TITLE
few fixes for release

### DIFF
--- a/Calypso-Environment-Core.package/ClyEnvironmentContentMetadata.class/instance/newCursor.st
+++ b/Calypso-Environment-Core.package/ClyEnvironmentContentMetadata.class/instance/newCursor.st
@@ -1,3 +1,8 @@
 operations
 newCursor
+	self isBuiltInEmptyScope ifTrue: [ 
+		"to avoid extra communication in remote scenario in trivial case
+		we just return local empty content" 
+		^ (self contentClass emptyInScopeOf: queryScopeClass) newCursor ].
+	
 	^queryScope query: buildingQuery

--- a/Calypso-Tools-CoreBrowser.package/ClyBrowser.class/instance/changeNavigationStateBy..st
+++ b/Calypso-Tools-CoreBrowser.package/ClyBrowser.class/instance/changeNavigationStateBy..st
@@ -1,13 +1,18 @@
 navigation
 changeNavigationStateBy: aBlock
 
-	| state |
+	| state navigationFailed |
 	navigationStarted ifTrue: [^aBlock value].
 	navigationStarted := true.
+	navigationFailed := false.
 	state := self snapshotNavigationState.
-	[aBlock value.
-	(state isCurrentStateOf: self) ifFalse: [ 
-		self recordNavigationState: state.
-		self updateWindowTitle.				
-		self rebuildAllTools]
-	] ensure: [ navigationStarted := false]
+	^[
+		aBlock on: Error do: [:err | 
+			navigationFailed := true. "this flag prevents any UI update in case of error"
+			err pass]
+	] ensure: [ 
+		navigationStarted := false.
+		navigationFailed | (state isCurrentStateOf: self) ifFalse: [ 
+			self recordNavigationState: state.
+			self updateWindowTitle.				
+			self rebuildAllTools]]

--- a/Calypso-Tools-CoreBrowser.package/ClyBrowser.class/instance/changeNavigationStateBy..st
+++ b/Calypso-Tools-CoreBrowser.package/ClyBrowser.class/instance/changeNavigationStateBy..st
@@ -5,9 +5,9 @@ changeNavigationStateBy: aBlock
 	navigationStarted ifTrue: [^aBlock value].
 	navigationStarted := true.
 	state := self snapshotNavigationState.
-	^aBlock ensure: [ 
-		navigationStarted := false.
-		(state isCurrentStateOf: self) ifFalse: [ 
-			self recordNavigationState: state.
-			self updateWindowTitle.				
-			self rebuildAllTools]]
+	[aBlock value.
+	(state isCurrentStateOf: self) ifFalse: [ 
+		self recordNavigationState: state.
+		self updateWindowTitle.				
+		self rebuildAllTools]
+	] ensure: [ navigationStarted := false]

--- a/Calypso-Tools-CoreBrowser.package/ClyDataSource.class/instance/environmentChanged..st
+++ b/Calypso-Tools-CoreBrowser.package/ClyDataSource.class/instance/environmentChanged..st
@@ -1,7 +1,11 @@
 system changes
 environmentChanged: anEnvironmentChanged
 
+	self isClosed ifTrue: [ ^self ].
+	
 	self updateItems.
 	[self isClosed ifFalse: [ 
+		"This check is required for the case when it will be triggered from nont UI process.
+		It will defer update and in time when it will be executed data source can became closed"
 		itemsView itemsOf: self wereUpdatedBy: anEnvironmentChanged.
 		self tableRefresh]] updateCalypsoUI

--- a/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/asItemsScope..st
+++ b/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/asItemsScope..st
@@ -1,0 +1,6 @@
+converting
+asItemsScope: anEnvironmentScopeClass
+	| actualItems |
+	actualItems := self uniformActualObjects.
+	
+	^anEnvironmentScopeClass basis: actualItems

--- a/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/asItemsScope.st
+++ b/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/asItemsScope.st
@@ -1,6 +1,3 @@
 converting
 asItemsScope
-	| actualItems |
-	actualItems := self uniformActualObjects.
-	
-	^self itemScope basis: actualItems
+	^self asItemsScope: self itemScope

--- a/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/query..st
+++ b/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/query..st
@@ -1,7 +1,4 @@
 query
 query: anEnvironmentContentClass	
-	| actualItems |
-	self isEmpty ifTrue: [^(anEnvironmentContentClass emptyInScopeOf: self itemScope) newCursor].
-	
-	^self lastSelectedItem ownerDataSource
-			query: anEnvironmentContentClass inNewScope: self asItemsScope
+
+	^self query: anEnvironmentContentClass inScope: self itemScope

--- a/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/query.inScope..st
+++ b/Calypso-Tools-CoreBrowser.package/ClyDataSourceSelection.class/instance/query.inScope..st
@@ -1,10 +1,11 @@
 query
 query: anEnvironmentContentClass inScope: anEnvironmentScopeClass
-	| actualItems |
-	self isEmpty ifTrue: [^(anEnvironmentContentClass emptyInScopeOf: self itemScope) newCursor].
 
-	actualItems := self uniformActualObjects.
-	
+	self isEmpty ifTrue: [
+		"to avoid extra communication in remote scenario in trivial case
+		we just return local empty content" 
+		^(anEnvironmentContentClass emptyInScopeOf: anEnvironmentScopeClass) newCursor].
+
 	^self lastSelectedItem ownerDataSource
 			query: anEnvironmentContentClass 
-			inNewScope: (anEnvironmentScopeClass basis: actualItems)
+			inNewScope: (self asItemsScope: anEnvironmentScopeClass)


### PR DESCRIPTION
extra guard to skip update of closed data sourcechangeNavigationStateBY: is fixed to always update UI when navigation block is succeed. When there were errors updating will not happen