### PR TITLE
MethodScope basis type is fixed

### DIFF
--- a/Calypso-Environment-System.package/ClyMethodScope.class/instance/basisObjects..st
+++ b/Calypso-Environment-System.package/ClyMethodScope.class/instance/basisObjects..st
@@ -1,0 +1,3 @@
+accessing
+basisObjects: anObject
+	basisObjects := anObject asIdentitySet


### PR DESCRIPTION
MethodScope should manage basis as IdentitySet because simple method equality  is very specific for compioled methods which is not suitable to cache scopes