### PR TITLE
Fix #105 - Improved World Menu/Tool Registration

### DIFF
--- a/Calypso-Tools-SystemBrowser.package/ClySystemBrowser.class/class/registerToolsOn..st
+++ b/Calypso-Tools-SystemBrowser.package/ClySystemBrowser.class/class/registerToolsOn..st
@@ -1,4 +1,5 @@
 tools registration
 registerToolsOn: registry
 	"Add ourselves to registry. See [Smalltalk tools]" 
-	registry register: self as: #browser
+	registry browserTool: self
+	

--- a/Calypso-Tools-SystemBrowser.package/ClySystemBrowser.class/class/worldMenuOn..st
+++ b/Calypso-Tools-SystemBrowser.package/ClySystemBrowser.class/class/worldMenuOn..st
@@ -1,8 +1,18 @@
 world menu
 worldMenuOn: aBuilder 
 	<worldMenu> 
-	(aBuilder item: #'Calypso browser')	
-		order: 0;
-		help: 'Calypso browser';
+	| isDefaultBrowser target targetName |
+	isDefaultBrowser := Smalltalk tools browser = self.
+	isDefaultBrowser
+		ifTrue: [ 
+			target := Nautilus.
+			targetName := target name ]
+		ifFalse: [ 
+			target := self.
+			targetName := 'Calypso' ].
+	(aBuilder item: (targetName, ' browser') asSymbol)	
+		order: 0.5;
+		help: targetName, ' browser';
 		icon: (self iconNamed: #nautilus);
-		action: [ self open ]
+		action: [ target open ]
+		


### PR DESCRIPTION
# World Menu
- [Enh]: Toggle option to show either Nautilus or Calypso, whichever is not currently the default
- [Enh]: Demote menu item order to allow a bit of room for user-defined items

# Tool Registration
 - [Refactor]: Use registry's `#browserTool:`