### PR TITLE
dev

### DIFF
--- a/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/prepareCleanInitialStateWithoutFilter.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/prepareCleanInitialStateWithoutFilter.st
@@ -1,0 +1,6 @@
+initialization
+prepareCleanInitialStateWithoutFilter
+
+	methodGroupQuery := ClyAllMethodGroups sortedFrom: (metaLevelScope emptyIn: navigationEnvironment).
+	
+	self switchToPackages

--- a/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/prepareInitialState.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/prepareInitialState.st
@@ -1,8 +1,7 @@
-navigation
+initialization
 prepareInitialState
 
-	methodGroupQuery := ClyAllMethodGroups sortedFrom: (metaLevelScope emptyIn: navigationEnvironment).
+	self prepareCleanInitialStateWithoutFilter.
 	
-	self switchToPackages.	
 	DefaultPackageFilter ifNotNil: [ 
 		packageView activateFilterWith: DefaultPackageFilter]

--- a/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/prepareInitialStateBy..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/prepareInitialStateBy..st
@@ -1,0 +1,7 @@
+initialization
+prepareInitialStateBy: aBlock
+	"This override is required to avoid default filter when special state for browser is requested"
+	
+	navigationHistory ignoreNavigationDuring: [		
+		self prepareCleanInitialStateWithoutFilter.
+		aBlock valueWithPossibleArgument: self]


### PR DESCRIPTION
very suprizing  bad bug is fixed: due to active package filter all new browsers requested for concrete class/package are switched to empty view (because filter is updated in background with delay).
Now when there is special state to open browser package filter is not used