### PR TITLE
dev

### DIFF
--- a/Calypso-NavigationModel-Tests.package/ClyBrowserQueryCursorTestCase.class/instance/testMoveToItemWhichNotSatisfiesCondition.st
+++ b/Calypso-NavigationModel-Tests.package/ClyBrowserQueryCursorTestCase.class/instance/testMoveToItemWhichNotSatisfiesCondition.st
@@ -1,0 +1,11 @@
+tests
+testMoveToItemWhichNotSatisfiesCondition
+	
+	| found |
+	found := cursor moveToItemWhich: [:each | each actualObject = Object].
+	self assert: found.
+	self assert: cursor position equals: 2.
+	
+	found := cursor moveToItemWhich: [:each | false].
+	self deny: found.	
+	self assert: cursor position equals: 2

--- a/Calypso-NavigationModel-Tests.package/ClyBrowserQueryCursorTestCase.class/instance/testMoveToItemWhichSatisfiesCondition.st
+++ b/Calypso-NavigationModel-Tests.package/ClyBrowserQueryCursorTestCase.class/instance/testMoveToItemWhichSatisfiesCondition.st
@@ -1,0 +1,9 @@
+tests
+testMoveToItemWhichSatisfiesCondition
+	
+	| found |
+	found := cursor moveToItemWhich: [:each | each actualObject = Object].
+	
+	self assert: found.	
+	self assert: cursor position equals: 2.
+	self assert: cursor currentItem actualObject equals: Object.

--- a/Calypso-NavigationModel-Tests.package/ClyBrowserQueryCursorTestCase.class/instance/testMoveToItemWhichSatisfiesConditionWhenItNotExistsInCache.st
+++ b/Calypso-NavigationModel-Tests.package/ClyBrowserQueryCursorTestCase.class/instance/testMoveToItemWhichSatisfiesConditionWhenItNotExistsInCache.st
@@ -1,0 +1,10 @@
+tests
+testMoveToItemWhichSatisfiesConditionWhenItNotExistsInCache
+	
+	| found |
+	cursor cleanCache.
+	found := cursor moveToItemWhich: [:each | each actualObject = Object].
+	
+	self assert: found.	
+	self assert: cursor position equals: 2.
+	self assert: cursor currentItem actualObject equals: Object.

--- a/Calypso-NavigationModel-Tests.package/ClyCompositeQueryTestCase.class/instance/testFixingStateBeforeExecutionShouldFixSubqueriesState.st
+++ b/Calypso-NavigationModel-Tests.package/ClyCompositeQueryTestCase.class/instance/testFixingStateBeforeExecutionShouldFixSubqueriesState.st
@@ -1,0 +1,8 @@
+tests
+testFixingStateBeforeExecutionShouldFixSubqueriesState
+
+	query fixStateBeforeExecution.
+	
+	query subqueries do: [ :each | 
+		self assert: each isReadOnlyObject.
+		self assert: each scope isReadOnlyObject]

--- a/Calypso-NavigationModel-Tests.package/ClyNavigationEnvironmentTests.class/instance/testMakeQueryOfResultAsReadOnlyObjectWhenItIsExecuted.st
+++ b/Calypso-NavigationModel-Tests.package/ClyNavigationEnvironmentTests.class/instance/testMakeQueryOfResultAsReadOnlyObjectWhenItIsExecuted.st
@@ -1,0 +1,8 @@
+tests
+testMakeQueryOfResultAsReadOnlyObjectWhenItIsExecuted
+
+	| query |
+	query := self createQueryFromScopeOf: self class.
+	environment query: query.
+	
+	self assert: query isReadOnlyObject

--- a/Calypso-NavigationModel-Tests.package/ClyNavigationEnvironmentTests.class/instance/testMakeQueryScopeOfResultAsReadOnlyObjectWhenItIsExecuted.st
+++ b/Calypso-NavigationModel-Tests.package/ClyNavigationEnvironmentTests.class/instance/testMakeQueryScopeOfResultAsReadOnlyObjectWhenItIsExecuted.st
@@ -1,0 +1,8 @@
+tests
+testMakeQueryScopeOfResultAsReadOnlyObjectWhenItIsExecuted
+
+	| query |
+	query := self createQueryFromScopeOf: self class.
+	environment query: query.
+	
+	self assert: query scope isReadOnlyObject

--- a/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testFixingStateBeforeExecution.st
+++ b/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testFixingStateBeforeExecution.st
@@ -1,0 +1,7 @@
+tests
+testFixingStateBeforeExecution
+
+	query fixStateBeforeExecution.
+	
+	self assert: query isReadOnlyObject.
+	self assert: query scope isReadOnlyObject

--- a/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testHasReadonlyRequiredResultByDefault.st
+++ b/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testHasReadonlyRequiredResultByDefault.st
@@ -1,0 +1,4 @@
+tests
+testHasReadonlyRequiredResultByDefault
+
+	self assert: query requiredResult isReadOnlyObject

--- a/Calypso-NavigationModel.package/ClyCompositeQuery.class/instance/fixStateBeforeExecution.st
+++ b/Calypso-NavigationModel.package/ClyCompositeQuery.class/instance/fixStateBeforeExecution.st
@@ -1,0 +1,5 @@
+execution
+fixStateBeforeExecution
+	super fixStateBeforeExecution.
+	
+	subqueries do: [ :each | each fixStateBeforeExecution ]

--- a/Calypso-NavigationModel.package/ClyCompositeQuery.class/instance/subqueries..st
+++ b/Calypso-NavigationModel.package/ClyCompositeQuery.class/instance/subqueries..st
@@ -6,4 +6,4 @@ subqueries: aCollection
 	subqueries := aCollection asSet.
 	subscopes := subqueries collect: [:each | each scope].
 	scope := ClyCompositeScope on: subscopes.
-	requiredResult := subqueries anyOne requiredResult 
+	self requiredResult: subqueries anyOne requiredResult 

--- a/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/query..st
+++ b/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/query..st
@@ -6,6 +6,10 @@ query: aQuery
 	result := queryCache at: aQuery ifAbsent: [nil]. "cache is weak dict where ifAbsentPut: not works"
 	result ifNil: [  
 		result := aQuery prepareResultIn: self.
+		aQuery fixStateBeforeExecution.
+		"We should ensure that state of query will not be modified after execution 
+		because it is the key in cache.
+		So aQuery is supposed to become readonly object together with required internal state"
 		queryCache at: aQuery put: result].	
 	result rebuildIfNeeded.
 	^result

--- a/Calypso-NavigationModel.package/ClyQuery.class/instance/fixStateBeforeExecution.st
+++ b/Calypso-NavigationModel.package/ClyQuery.class/instance/fixStateBeforeExecution.st
@@ -1,0 +1,8 @@
+execution
+fixStateBeforeExecution
+	"Here the query should become readonly object together with all required internal state. By default it is only instance itself. But subclasses like composite query force additional objects (subqueries) to fix their state.
+	If query needs additional state for execution 
+	it should retrieve it in prepare method which is executed before readonly fix"
+	self prepareStateBeforeExecution.
+	self beReadOnlyObject.
+	scope beReadOnlyObject

--- a/Calypso-NavigationModel.package/ClyQuery.class/instance/initialize.st
+++ b/Calypso-NavigationModel.package/ClyQuery.class/instance/initialize.st
@@ -2,4 +2,4 @@ initialization
 initialize
 	super initialize.
 	self resetScope.
-	requiredResult := self defaultResult
+	self requiredResult: self defaultResult

--- a/Calypso-NavigationModel.package/ClyQuery.class/instance/prepareStateBeforeExecution.st
+++ b/Calypso-NavigationModel.package/ClyQuery.class/instance/prepareStateBeforeExecution.st
@@ -1,0 +1,4 @@
+execution
+prepareStateBeforeExecution
+	"Here subclasses can initialize some additional state from own instance variables
+	which is required for execution"

--- a/Calypso-NavigationModel.package/ClyQuery.class/instance/requiredResult..st
+++ b/Calypso-NavigationModel.package/ClyQuery.class/instance/requiredResult..st
@@ -1,3 +1,4 @@
 accessing
-requiredResult: aQueryResultClass
-	requiredResult := aQueryResultClass
+requiredResult: aQueryResult
+	requiredResult := aQueryResult.
+	requiredResult beReadOnlyObject 

--- a/Calypso-NavigationModel.package/ClyQueryResultBrowserAdapter.class/instance/itemsStartingWhere.count..st
+++ b/Calypso-NavigationModel.package/ClyQueryResultBrowserAdapter.class/instance/itemsStartingWhere.count..st
@@ -1,0 +1,10 @@
+queries
+itemsStartingWhere: blockCondition count: size
+	
+	actualResult protectItemsWhile: [
+		actualResult items doWithIndex: [ :each :i |
+			 (blockCondition value: each asCalypsoBrowserItem) 
+					ifTrue: [	^self itemsStartingAt: i count: size	]]
+	].
+
+	^#()

--- a/Calypso-NavigationModel.package/ClyScope.class/instance/bindTo..st
+++ b/Calypso-NavigationModel.package/ClyScope.class/instance/bindTo..st
@@ -1,3 +1,6 @@
 accessing
 bindTo: aNavigationEnvironment
-	environment := aNavigationEnvironment 
+	environment ifNil: [ environment := aNavigationEnvironment ].
+	
+	environment == aNavigationEnvironment
+		ifFalse: [ self error: 'Scope should never be rebound to new environment' ]

--- a/Calypso-SystemQueries.package/ClyMessageSenders.class/instance/prepareStateBeforeExecution.st
+++ b/Calypso-SystemQueries.package/ClyMessageSenders.class/instance/prepareStateBeforeExecution.st
@@ -1,0 +1,8 @@
+execution
+prepareStateBeforeExecution
+	super prepareStateBeforeExecution.
+	
+	"Special selector indexes are required for lookup in method.
+	Here it is collected in advance to be used during execution
+	because after execution query become readonly object"
+	self specialSelectorIndexes

--- a/Calypso-SystemQueries.package/ClyMessageSenders.class/instance/specialSelectorIndexes.st
+++ b/Calypso-SystemQueries.package/ClyMessageSenders.class/instance/specialSelectorIndexes.st
@@ -1,4 +1,4 @@
-testing
+accessing
 specialSelectorIndexes
 	^specialSelectorIndexes ifNil: [ 
 		specialSelectorIndexes := selectors collect: [:each | Smalltalk specialSelectorIndexOrNil: each]]


### PR DESCRIPTION
Important logic to prevent broken query cache when users modify query state (or it internal objects) after query is executed.

So query now has method fixStateBeforeExecution which makes it read only object. CompositeQuery extend it to force subqueries become readonly.
Also scope of query and required result become readonly (they all participate n cache computation)