### PR TITLE
dev

### DIFF
--- a/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/applyChanges.st
+++ b/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/applyChanges.st
@@ -7,7 +7,9 @@ applyChanges
 	selector ifNil: [ ^false ].
 	
 	newMethod := selectedClass >> selector.
-	methodTags ifEmpty: [ MethodClassifier classify: newMethod ].
+	methodTags ifEmpty: [ 
+		MethodClassifier classify: newMethod.
+		methodTags := newMethod tags ].
 	self tagAndPackageEditingMethod: newMethod.
 	
 	self removeFromBrowser.


### PR DESCRIPTION
MethodCreationTool ignores MethodClassifier by following logic. Now it is fixed