### PR TITLE
More bug fixes

### DIFF
--- a/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/buildActualResult.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/buildActualResult.st
@@ -1,9 +1,10 @@
 building
 buildActualResult
-
-	actualResult := buildingQuery execute.
-	items := actualResult items.
-	metadata := nil.
+	"The loop here prevents the race condition when actual query is just executed 
+	but system is changed and this change reset built result which means nil returned from #items.
+	In that case we just repeat query again"
+	[actualResult := buildingQuery execute.
+	(items := actualResult items) isNil] whileTrue.
 	self collectMetadata.
 	buildProcess := nil.
 	self notifyObservers.

--- a/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/collectMetadata.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/collectMetadata.st
@@ -1,0 +1,8 @@
+building
+collectMetadata
+	"In async query we always collect metadata in background 
+	and full execution process completes only after this.
+	So no protection is needed here and no lazy logic over metadata variable"
+	metadata := ClyQueryResultMetadata new.
+	environment pluginsDo: [:each | 
+		buildingQuery collectMetadataOf: self by: each	]

--- a/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/cleanGarbageInCache.st
+++ b/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/cleanGarbageInCache.st
@@ -1,4 +1,5 @@
 cleaning
 cleanGarbageInCache
 
-	queryCache clyCleanGarbage
+	accessGuard critical: [ 
+		queryCache clyCleanGarbage]

--- a/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/initialize.st
+++ b/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/initialize.st
@@ -3,6 +3,7 @@ initialize
 	super initialize.
 	
 	accessGuard := Mutex new.
+	updateGuard := Mutex new.
 	plugins := OrderedCollection new.
 	queryCache := WeakValueDictionary new.
 	updateStrategy := ClyInstantEnvironmentUpdateStrategy new

--- a/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/query..st
+++ b/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/query..st
@@ -10,6 +10,6 @@ query: aQuery
 		"We should ensure that state of query will not be modified after execution 
 		because it is the key in cache.
 		So aQuery is supposed to become readonly object together with required internal state"
-		queryCache at: aQuery put: result].	
+		accessGuard critical: [ queryCache at: aQuery put: result]].	
 	result rebuildIfNeeded.
 	^result

--- a/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/updateUsing.by..st
+++ b/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/instance/updateUsing.by..st
@@ -6,11 +6,11 @@ updateUsing: newUpdateStrategy by: updateBlock
 	Breaking mutex is done by creating new one which meand that current process
 	is not guarded any more and proceeding execution in debugger can lead to some errors in rare cases. But it is less problem than locked UI"
 	| oldStrategy |
-	[accessGuard critical: [ 
+	[updateGuard critical: [ 
 		oldStrategy := updateStrategy.
 		updateStrategy := newUpdateStrategy.
 		updateBlock on: Exception do: [ :err |
-				accessGuard := Mutex new.
+				updateGuard := Mutex new.
 				err pass]]
 	] ensure: [ 			
 			oldStrategy ifNotNil: [

--- a/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/properties.json
+++ b/Calypso-NavigationModel.package/ClyNavigationEnvironment.class/properties.json
@@ -11,6 +11,7 @@
 		"plugins",
 		"updateStrategy",
 		"accessGuard",
+		"updateGuard",
 		"system",
 		"queryCache"
 	],

--- a/Calypso-NavigationModel.package/WeakValueDictionary.extension/instance/clyCleanGarbage.st
+++ b/Calypso-NavigationModel.package/WeakValueDictionary.extension/instance/clyCleanGarbage.st
@@ -1,6 +1,12 @@
 *Calypso-NavigationModel
 clyCleanGarbage
 
-	| garbage |
-	garbage := array select: [ :ass | ass notNil and: [ass value isNil] ].
-	garbage do: [ :ass | self removeKey: ass key ]
+	| firstFound |
+	array withIndexDo: [:ass :index | 
+		(ass notNil and: [ass value isNil]) ifTrue: [ 
+			array at: index put: nil.
+			tally := tally - 1.
+			firstFound ifNil: [firstFound := index]]].
+	
+	firstFound ifNotNil: [ 
+		self fixCollisionsFrom: firstFound]

--- a/Calypso-SystemPlugins-Reflectivity-Queries.package/MetalinkChanged.extension/instance/affectsMethod..st
+++ b/Calypso-SystemPlugins-Reflectivity-Queries.package/MetalinkChanged.extension/instance/affectsMethod..st
@@ -1,0 +1,4 @@
+*Calypso-SystemPlugins-Reflectivity-Queries
+affectsMethod: aMethod
+
+	^link methods anySatisfy: [:each | each == aMethod ]

--- a/Calypso-SystemPlugins-Reflectivity-Queries.package/MetalinkChanged.extension/instance/canAffectResultOfMethodQuery..st
+++ b/Calypso-SystemPlugins-Reflectivity-Queries.package/MetalinkChanged.extension/instance/canAffectResultOfMethodQuery..st
@@ -1,0 +1,5 @@
+*Calypso-SystemPlugins-Reflectivity-Queries
+canAffectResultOfMethodQuery: aMethodQuery
+
+	^link methods anySatisfy: [:each | 
+		aMethodQuery isAffectedByChangedMethod: each ]


### PR DESCRIPTION
- Query cache is correctly protected- Query cache garbage collection is optimized- MetalingChanged handing is fixed. Now method query results are corectly updated by it.- improved async query building process:
special loop to prevent race condition when actual query is reset just after execution
and metadata collection without mutex protection which broke actual made background processing not really background and could lead to deadlock