### PR TITLE
missingParts

### DIFF
--- a/Calypso-SystemPlugins-Flags-Browser.package/ClyFlaggingMethods.extension/instance/decorateResultMethodEditor..st
+++ b/Calypso-SystemPlugins-Flags-Browser.package/ClyFlaggingMethods.extension/instance/decorateResultMethodEditor..st
@@ -1,0 +1,4 @@
+*Calypso-SystemPlugins-Flags-Browser
+decorateResultMethodEditor: aMethodEditor
+
+	aMethodEditor selectAnySelector: #(flag:)

--- a/Calypso-SystemPlugins-InheritanceAnalysis-Queries.package/ClyInheritanceAnalysisEnvironmentPlugin.class/instance/checkClassIsAbstract..st
+++ b/Calypso-SystemPlugins-InheritanceAnalysis-Queries.package/ClyInheritanceAnalysisEnvironmentPlugin.class/instance/checkClassIsAbstract..st
@@ -1,0 +1,10 @@
+item decoration
+checkClassIsAbstract: aClass
+	"Method is copied from Pharo7 Behavior>>isAbstract"
+	
+	aClass withAllSuperclassesDo: [ :eachClass | 
+		eachClass methodsDo: [ :eachMethod |
+			(eachMethod isAbstract and: [ (aClass lookupSelector: eachMethod selector) isAbstract ])
+				ifTrue: [ ^true ]]].
+	
+	^false

--- a/Calypso-SystemPlugins-InheritanceAnalysis-Queries.package/ClyInheritanceAnalysisEnvironmentPlugin.class/instance/decorateBrowserItem.ofClass..st
+++ b/Calypso-SystemPlugins-InheritanceAnalysis-Queries.package/ClyInheritanceAnalysisEnvironmentPlugin.class/instance/decorateBrowserItem.ofClass..st
@@ -1,5 +1,8 @@
 item decoration
 decorateBrowserItem: anItem ofClass: aClass
-
-	aClass hasAbstractMethods ifTrue: [ 
+	(aClass respondsTo: #isAbstract) ifTrue: [ 
+		aClass isAbstract ifTrue: [ anItem markWith: ClyAbstractItemTag ].
+		^self].
+		
+	(self checkClassIsAbstract: aClass) ifTrue: [ 
 		anItem markWith: ClyAbstractItemTag ]

--- a/Calypso-SystemPlugins-InheritanceAnalysis-Queries.package/ClyRequiredMethodGroupProvider.class/instance/isStatic.st
+++ b/Calypso-SystemPlugins-InheritanceAnalysis-Queries.package/ClyRequiredMethodGroupProvider.class/instance/isStatic.st
@@ -1,0 +1,3 @@
+testing
+isStatic
+	^true

--- a/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/applyChanges.st
+++ b/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/applyChanges.st
@@ -3,7 +3,11 @@ applyChanges
 	| newMethod selector selectedClass |
 	selectedClass := self selectClassForNewMethodIfNone: [^false].
 	
-	selector := selectedClass compile: self pendingText asString notifying: textMorph.
+	selector := methodTags 
+		ifEmpty: [ selectedClass compile: self pendingText asString notifying: textMorph]
+		ifNotEmpty: [
+			selectedClass compile: self pendingText asString classified: methodTags anyOne notifying: textMorph].
+			
 	selector ifNil: [ ^false ].
 	
 	newMethod := selectedClass >> selector.


### PR DESCRIPTION
method creation with better logic to create method with specified tag if exist instead of tagging it at second step.requiredMethod group is fixedflaggingMethods query decorating method editor to select flag message