### PR TITLE
semiAsyncQuery

### DIFF
--- a/Calypso-Browser.package/ClyBrowser.class/instance/buildWindow.st
+++ b/Calypso-Browser.package/ClyBrowser.class/instance/buildWindow.st
@@ -1,0 +1,8 @@
+opening/closing
+buildWindow	
+	| window |
+	window := (SystemWindow labelled: self newWindowTitle) model: self.
+	window 
+		addMorph: self frame: (0@0 extent: 1@1);
+		updatePaneColors.
+	^window

--- a/Calypso-Browser.package/ClyBrowser.class/instance/openInWindow..st
+++ b/Calypso-Browser.package/ClyBrowser.class/instance/openInWindow..st
@@ -3,10 +3,7 @@ openInWindow: aWindow
 	| groupWindow myWindow |
 	groupWindow := self createWindowGroupFrom: aWindow.
 	
-	myWindow := (SystemWindow labelled: self newWindowTitle) model: self.
-	myWindow 
-		addMorph: self frame: (0@0 extent: 1@1);
-		updatePaneColors.
+	myWindow := self buildWindow.
 	groupWindow addWindow: myWindow.
 	myWindow activate.
 	myWindow announceOpened

--- a/Calypso-Browser.package/ClyDataSource.class/instance/runUpdate.st
+++ b/Calypso-Browser.package/ClyDataSource.class/instance/runUpdate.st
@@ -1,7 +1,7 @@
 private
 runUpdate
-	dirty ifFalse: [ ^self ].
 	self isClosed ifTrue: [^self].
+	dirty ifFalse: [ ^self ].
 	
 	dirty := false.
 	itemCursor updateItemCache.

--- a/Calypso-Browser.package/ClyDataSource.class/instance/runUpdate.st
+++ b/Calypso-Browser.package/ClyDataSource.class/instance/runUpdate.st
@@ -1,5 +1,6 @@
 private
 runUpdate
+	dirty ifFalse: [ ^self ].
 	self isClosed ifTrue: [^self].
 	
 	dirty := false.

--- a/Calypso-Browser.package/StringMorph.extension/instance/addEmphasis..st
+++ b/Calypso-Browser.package/StringMorph.extension/instance/addEmphasis..st
@@ -1,4 +1,0 @@
-*Calypso-Browser
-addEmphasis: aTextEmphasis
-
-	self emphasis: (emphasis bitOr: aTextEmphasis emphasisCode)

--- a/Calypso-Browser.package/StringMorph.extension/instance/clyAddEmphasis..st
+++ b/Calypso-Browser.package/StringMorph.extension/instance/clyAddEmphasis..st
@@ -1,0 +1,4 @@
+*Calypso-Browser
+clyAddEmphasis: aTextEmphasis
+	"For compatibility between Pharo 6 and Pharo 7 and to not produce overrides"
+	self emphasis: (emphasis bitOr: aTextEmphasis emphasisCode)

--- a/Calypso-NavigationModel-Tests.package/ClyAsyncQueryResultTests.class/instance/testNotBuiltByDefault.st
+++ b/Calypso-NavigationModel-Tests.package/ClyAsyncQueryResultTests.class/instance/testNotBuiltByDefault.st
@@ -1,6 +1,6 @@
 tests
 testNotBuiltByDefault
 
-	queryResult := ClyAsyncQueryResult for: query.
+	queryResult := queryResult class for: query.
 	
 	self deny: queryResult isBuilt

--- a/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testComparingWithAnotherAsyncQueryWithDifferentAsyncResult.st
+++ b/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testComparingWithAnotherAsyncQueryWithDifferentAsyncResult.st
@@ -1,0 +1,7 @@
+tests
+testComparingWithAnotherAsyncQueryWithDifferentAsyncResult
+
+	| anotherQuery |
+	anotherQuery := query semiAsync.
+	
+	self deny: query = anotherQuery

--- a/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testConvertingToSemiAsyncQuery.st
+++ b/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testConvertingToSemiAsyncQuery.st
@@ -1,0 +1,11 @@
+tests
+testConvertingToSemiAsyncQuery
+
+	| convertedQuery |
+	convertedQuery := query semiAsync.
+	
+	self assert: convertedQuery asyncResult class equals: ClySemiAsyncQueryResult.
+	self deny: convertedQuery == query.
+	self assert: convertedQuery class equals: query class.
+	self assert: convertedQuery requiredResult == query requiredResult.
+	self assert: convertedQuery scope == query scope

--- a/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testHasAsyncResultbyDefault.st
+++ b/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testHasAsyncResultbyDefault.st
@@ -1,0 +1,4 @@
+tests
+testHasAsyncResultbyDefault
+
+	self assert: query asyncResult class equals: ClyAsyncQueryResult

--- a/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testPrepareResultForExecutionWhenItIsSemiAsync.st
+++ b/Calypso-NavigationModel-Tests.package/ClyAsyncQueryTests.class/instance/testPrepareResultForExecutionWhenItIsSemiAsync.st
@@ -1,10 +1,10 @@
 tests
-testPrepareResultForExecution
+testPrepareResultForExecutionWhenItIsSemiAsync
 
 	| preparedResult |
-	preparedResult := query prepareNewResult.
+	preparedResult := query semiAsync prepareNewResult.
 	
-	self assert: preparedResult class equals: ClyAsyncQueryResult.
+	self assert: preparedResult class equals: ClySemiAsyncQueryResult.
 	self assert: preparedResult buildingQuery == query actualQuery.
 	self assert: preparedResult environment == environment.
 	self assert: preparedResult isProtected

--- a/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testConvertingToAsyncQuery.st
+++ b/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testConvertingToAsyncQuery.st
@@ -1,0 +1,11 @@
+tests
+testConvertingToAsyncQuery
+
+	| convertedQuery |
+	convertedQuery := query async.
+	
+	self assert: convertedQuery class equals: ClyAsyncQuery.
+	self assert: convertedQuery actualQuery == query.
+	self assert: convertedQuery requiredResult == query requiredResult.
+	self assert: convertedQuery scope == query scope.
+	self assert: convertedQuery asyncResult class equals: ClyAsyncQueryResult

--- a/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testConvertingToSemiAsyncQuery.st
+++ b/Calypso-NavigationModel-Tests.package/ClyQueryTestCase.class/instance/testConvertingToSemiAsyncQuery.st
@@ -1,0 +1,11 @@
+tests
+testConvertingToSemiAsyncQuery
+
+	| convertedQuery |
+	convertedQuery := query semiAsync.
+	
+	self assert: convertedQuery class equals: ClyAsyncQuery.
+	self assert: convertedQuery actualQuery == query.
+	self assert: convertedQuery requiredResult == query requiredResult.
+	self assert: convertedQuery scope == query scope.
+	self assert: convertedQuery asyncResult class equals: ClySemiAsyncQueryResult

--- a/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/class/shouldInheritSelectors.st
+++ b/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/class/shouldInheritSelectors.st
@@ -1,0 +1,3 @@
+testing
+shouldInheritSelectors
+	^true

--- a/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/instance/createQueryResult.st
+++ b/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/instance/createQueryResult.st
@@ -1,0 +1,3 @@
+running
+createQueryResult
+	^ClySemiAsyncQueryResult for: query

--- a/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/instance/testFastQueryShouldBeSync.st
+++ b/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/instance/testFastQueryShouldBeSync.st
@@ -1,0 +1,8 @@
+tests
+testFastQueryShouldBeSync
+
+	query passExecution.
+	queryResult rebuild.
+	
+	self assert: queryResult isBuilt.
+	self assert: queryResult buildProcess isNil

--- a/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/properties.json
+++ b/Calypso-NavigationModel-Tests.package/ClySemiAsyncQueryResultTests.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "ClyAsyncQueryResultTests",
+	"category" : "Calypso-NavigationModel-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ClySemiAsyncQueryResultTests",
+	"type" : "normal"
+}

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/^equals.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/^equals.st
@@ -1,0 +1,7 @@
+comparing
+= anObject
+	"Answer whether the receiver and anObject represent the same object."
+
+	self == anObject ifTrue: [ ^ true ].
+	super = anObject ifFalse: [ ^ false ].
+	^ asyncResult = anObject asyncResult

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/asyncResult..st
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/asyncResult..st
@@ -1,0 +1,3 @@
+accessing
+asyncResult: anObject
+	asyncResult := anObject

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/asyncResult.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/asyncResult.st
@@ -1,0 +1,3 @@
+accessing
+asyncResult
+	^ asyncResult

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/hash.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/hash.st
@@ -1,0 +1,5 @@
+comparing
+hash
+	"Answer an integer value that is related to the identity of the receiver."
+
+	^super hash bitXor: asyncResult hash

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/initialize.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/initialize.st
@@ -1,0 +1,5 @@
+initialization
+initialize
+	super initialize.
+	
+	asyncResult := ClyAsyncQueryResult new

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/prepareNewResult.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/prepareNewResult.st
@@ -1,4 +1,4 @@
 execution
 prepareNewResult
 	
-	^ClyAsyncQueryResult for: self actualQuery
+	^asyncResult prepareNewFor: self actualQuery in: self environment

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/semiAsync.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/instance/semiAsync.st
@@ -1,0 +1,4 @@
+converting
+semiAsync
+	^self copy 
+		asyncResult: ClySemiAsyncQueryResult new

--- a/Calypso-NavigationModel.package/ClyAsyncQuery.class/properties.json
+++ b/Calypso-NavigationModel.package/ClyAsyncQuery.class/properties.json
@@ -5,7 +5,9 @@
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
-	"instvars" : [ ],
+	"instvars" : [
+		"asyncResult"
+	],
 	"name" : "ClyAsyncQuery",
 	"type" : "normal"
 }

--- a/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/rebuild.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/rebuild.st
@@ -1,12 +1,7 @@
 building
 rebuild
-	| semaphore |
 	self initializeItems.	
 	metadata ifNil: [metadata := ClyQueryResultMetadata new].
 	metadata addProperty: ClyBackgroundProcessingTag instance.
 	
-	semaphore := Semaphore new.
-	buildProcess := [self buildActualResult. semaphore signal] 
-		forkAt: Processor userBackgroundPriority 
-		named: 'Build result of ', buildingQuery printString.
-	semaphore wait: 500 milliSeconds "Idea to allow query to be processed fastly and hide async execution for users in that case"
+	self runBuildProcess

--- a/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/rebuild.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/rebuild.st
@@ -1,9 +1,12 @@
 building
 rebuild
+	| semaphore |
 	self initializeItems.	
 	metadata ifNil: [metadata := ClyQueryResultMetadata new].
 	metadata addProperty: ClyBackgroundProcessingTag instance.
 	
-	buildProcess := [self buildActualResult] 
+	semaphore := Semaphore new.
+	buildProcess := [self buildActualResult. semaphore signal] 
 		forkAt: Processor userBackgroundPriority 
-		named: 'Build result of ', buildingQuery printString
+		named: 'Build result of ', buildingQuery printString.
+	semaphore wait: 500 milliSeconds "Idea to allow query to be processed fastly and hide async execution for users in that case"

--- a/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/runBuildProcess.st
+++ b/Calypso-NavigationModel.package/ClyAsyncQueryResult.class/instance/runBuildProcess.st
@@ -1,0 +1,6 @@
+building
+runBuildProcess
+
+	buildProcess := [self buildActualResult] 
+		forkAt: Processor userBackgroundPriority 
+		named: 'Build result of ', buildingQuery printString

--- a/Calypso-NavigationModel.package/ClyQuery.class/instance/semiAsync.st
+++ b/Calypso-NavigationModel.package/ClyQuery.class/instance/semiAsync.st
@@ -1,0 +1,4 @@
+converting
+semiAsync
+	^self async 
+		asyncResult: ClySemiAsyncQueryResult new

--- a/Calypso-NavigationModel.package/ClySemiAsyncQueryResult.class/instance/runBuildProcess.st
+++ b/Calypso-NavigationModel.package/ClySemiAsyncQueryResult.class/instance/runBuildProcess.st
@@ -1,0 +1,12 @@
+building
+runBuildProcess
+	"Idea is to look like sync query when it is fast enough.
+	I wait half second maximum until background query will be done.
+	If it will complete in time then users will not notice any progress indication
+	and they will think that query was sync"
+	| semaphore |
+	semaphore := Semaphore new.
+	buildProcess := [self buildActualResult. semaphore signal] 
+		forkAt: Processor userBackgroundPriority 
+		named: 'Build result of ', buildingQuery printString.
+	semaphore wait: 500 milliSeconds

--- a/Calypso-NavigationModel.package/ClySemiAsyncQueryResult.class/properties.json
+++ b/Calypso-NavigationModel.package/ClySemiAsyncQueryResult.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "",
+	"super" : "ClyAsyncQueryResult",
+	"category" : "Calypso-NavigationModel",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "ClySemiAsyncQueryResult",
+	"type" : "normal"
+}

--- a/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testNotSelectsMethodWithCritiquesWhenTheyNotComputedYet.st
+++ b/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testNotSelectsMethodWithCritiquesWhenTheyNotComputedYet.st
@@ -1,0 +1,4 @@
+tests
+testNotSelectsMethodWithCritiquesWhenTheyNotComputedYet
+
+	self deny: (query selectsMethod: (ClyClassWithProblemMethods >> #methodWithHalt))

--- a/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testSelectsMethodWithCritiques.st
+++ b/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testSelectsMethodWithCritiques.st
@@ -1,4 +1,0 @@
-tests
-testSelectsMethodWithCritiques
-
-	self assert: (query selectsMethod: (ClyClassWithProblemMethods >> #methodWithHalt))

--- a/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testSelectsMethodWithCritiquesWhenTheyExistAndComputedInAdvance.st
+++ b/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testSelectsMethodWithCritiquesWhenTheyExistAndComputedInAdvance.st
@@ -1,5 +1,5 @@
 tests
-testSelectsMethodWithCritiquesWhenTheyExistsAndComputedInAdvance
+testSelectsMethodWithCritiquesWhenTheyExistAndComputedInAdvance
 
 	| critiques |
 	critiques := query critiqueQuery async execute.

--- a/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testSelectsMethodWithCritiquesWhenTheyExistsAndComputedInAdvance.st
+++ b/Calypso-SystemPlugins-Critic-Queries-Tests.package/ClyAllProblemMethodsTests.class/instance/testSelectsMethodWithCritiquesWhenTheyExistsAndComputedInAdvance.st
@@ -1,0 +1,8 @@
+tests
+testSelectsMethodWithCritiquesWhenTheyExistsAndComputedInAdvance
+
+	| critiques |
+	critiques := query critiqueQuery async execute.
+	[ critiques isBuilt ] whileFalse: [ 30 milliSeconds wait ].
+
+	self assert: (query selectsMethod: (ClyClassWithProblemMethods >> #methodWithHalt))

--- a/Calypso-SystemPlugins-Critic-Queries.package/Announcement.extension/instance/affectsCritiques.st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/Announcement.extension/instance/affectsCritiques.st
@@ -1,0 +1,4 @@
+*Calypso-SystemPlugins-Critic-Queries
+affectsCritiques
+	"Critiques are very abstract concept. Any change can affect critique of arbitrary object"
+	^true

--- a/Calypso-SystemPlugins-Critic-Queries.package/Announcement.extension/properties.json
+++ b/Calypso-SystemPlugins-Critic-Queries.package/Announcement.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "Announcement"
+}

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyAllProblemMethods.class/instance/selectsMethod..st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyAllProblemMethods.class/instance/selectsMethod..st
@@ -1,7 +1,7 @@
 testing
 selectsMethod: aMethod
 	| critiques |
-	critiques := critiqueQuery execute.
+	critiques := self loadCritiquesAsync.
 	
 	^critiques items 
 		anySatisfy: [ :each | each sourceAnchor entity == aMethod ]

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyAsyncQueryIsDone.extension/instance/affectsCritiques.st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyAsyncQueryIsDone.extension/instance/affectsCritiques.st
@@ -1,0 +1,3 @@
+*Calypso-SystemPlugins-Critic-Queries
+affectsCritiques
+	^false

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyAsyncQueryIsDone.extension/properties.json
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyAsyncQueryIsDone.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "ClyAsyncQueryIsDone"
+}

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyCritiqueQuery.class/instance/isResult.affectedBy..st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyCritiqueQuery.class/instance/isResult.affectedBy..st
@@ -6,8 +6,7 @@ isResult: aQueryResult affectedBy: aSystemAnnouncement
 	It can of course lead to very poor system performance because critic computation is slow process
 	and triggering it after every system change can slow down system a lot.
 	So instead we just reset given aQueryResult silently. So users should update views manually"
-	(aSystemAnnouncement isKindOf: ClyAsyncQueryIsDone) ifTrue: [ ^false ].
+	aSystemAnnouncement affectsCritiques ifFalse: [ ^false ].
 	
-	aQueryResult forceLazyRebuild.
-	
+	aQueryResult forceLazyRebuild.	
 	^false "and we return false to prevent result observers to be notified"

--- a/Calypso-SystemPlugins-Deprecation-Browser.package/ClyDeprecatedMethodTableDecorator.class/class/decorateTableCell.of..st
+++ b/Calypso-SystemPlugins-Deprecation-Browser.package/ClyDeprecatedMethodTableDecorator.class/class/decorateTableCell.of..st
@@ -3,4 +3,4 @@ decorateTableCell: anItemCellMorph of: aDataSourceItem
 	| nameMorph |
 
 	nameMorph := anItemCellMorph label.
-	nameMorph addEmphasis: TextEmphasis struckOut
+	nameMorph clyAddEmphasis: TextEmphasis struckOut

--- a/Calypso-SystemPlugins-Deprecation-Browser.package/ClyDeprecatedMethods.extension/instance/decorateMethodGroupTableCell.of..st
+++ b/Calypso-SystemPlugins-Deprecation-Browser.package/ClyDeprecatedMethods.extension/instance/decorateMethodGroupTableCell.of..st
@@ -2,4 +2,4 @@
 decorateMethodGroupTableCell: anItemCellMorph of: groupItem
 	super decorateMethodGroupTableCell: anItemCellMorph of: groupItem.
 	
-	anItemCellMorph label addEmphasis: TextEmphasis struckOut
+	anItemCellMorph label clyAddEmphasis: TextEmphasis struckOut

--- a/Calypso-SystemPlugins-InheritanceAnalysis-Browser.package/ClyAbstractMethodTableDecorator.class/class/decorateTableCell.of..st
+++ b/Calypso-SystemPlugins-InheritanceAnalysis-Browser.package/ClyAbstractMethodTableDecorator.class/class/decorateTableCell.of..st
@@ -3,5 +3,5 @@ decorateTableCell: anItemCellMorph of: aDataSourceItem
 	| nameMorph |
 		
 	nameMorph := anItemCellMorph label.
-	nameMorph addEmphasis: TextEmphasis italic.
+	nameMorph clyAddEmphasis: TextEmphasis italic.
 	nameMorph color: (nameMorph color contrastingColorAdjustment) contrastingColorAdjustment

--- a/Calypso-SystemPlugins-SUnit-Queries.package/ClyTestCaseRan.class/instance/affectsCritiques.st
+++ b/Calypso-SystemPlugins-SUnit-Queries.package/ClyTestCaseRan.class/instance/affectsCritiques.st
@@ -1,0 +1,5 @@
+as yet unclassified
+affectsCritiques
+	"It should be packages in critic plugin package 
+	but for such simple message we can not do it"
+	^false

--- a/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/class/onDefaultEnvironment.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/class/onDefaultEnvironment.st
@@ -1,0 +1,6 @@
+opening
+onDefaultEnvironment
+	<script>
+	^ (self on: ClyNavigationEnvironment currentImage)
+			prepareCleanInitialStateWithoutFilter;
+			yourself

--- a/Calypso-SystemTools-QueryBrowser.package/ClyQueryBrowser.class/instance/showQueryResult.st
+++ b/Calypso-SystemTools-QueryBrowser.package/ClyQueryBrowser.class/instance/showQueryResult.st
@@ -6,4 +6,4 @@ showQueryResult
 		queryScopes add: systemQuery scope ].	
 	activeScope := systemQuery scope.	
 	
-	resultView showQuery: systemQuery
+	resultView showQuery: systemQuery async

--- a/Calypso-SystemTools-QueryBrowser.package/ClyQueryBrowser.class/instance/showQueryResult.st
+++ b/Calypso-SystemTools-QueryBrowser.package/ClyQueryBrowser.class/instance/showQueryResult.st
@@ -6,4 +6,4 @@ showQueryResult
 		queryScopes add: systemQuery scope ].	
 	activeScope := systemQuery scope.	
 	
-	resultView showQuery: systemQuery async
+	resultView showQuery: systemQuery semiAsync

--- a/Calypso-SystemTools-QueryBrowser.package/monticello.meta/categories.st
+++ b/Calypso-SystemTools-QueryBrowser.package/monticello.meta/categories.st
@@ -1,6 +1,6 @@
 SystemOrganization addCategory: #'Calypso-SystemTools-QueryBrowser'!
-SystemOrganization addCategory: 'Calypso-SystemTools-QueryBrowser-Commands-Controlling'!
-SystemOrganization addCategory: 'Calypso-SystemTools-QueryBrowser-Commands-Methods'!
-SystemOrganization addCategory: 'Calypso-SystemTools-QueryBrowser-Commands-Queries'!
-SystemOrganization addCategory: 'Calypso-SystemTools-QueryBrowser-Toolbar'!
-SystemOrganization addCategory: 'Calypso-SystemTools-QueryBrowser-UI'!
+SystemOrganization addCategory: #'Calypso-SystemTools-QueryBrowser-Commands-Controlling'!
+SystemOrganization addCategory: #'Calypso-SystemTools-QueryBrowser-Commands-Methods'!
+SystemOrganization addCategory: #'Calypso-SystemTools-QueryBrowser-Commands-Queries'!
+SystemOrganization addCategory: #'Calypso-SystemTools-QueryBrowser-Toolbar'!
+SystemOrganization addCategory: #'Calypso-SystemTools-QueryBrowser-UI'!


### PR DESCRIPTION
affectsCritiques is added to announcement with true because in general any change can affect critiques of abstract objects.
TestCaseRan implement it with false. So running tests will not recompute critiques.fix data source update logic. 
Update processed multiple times which was wrong.semyAsync query is added which is executed asynchronously but it pretends as sync for half a second. It makes fast queries always look sync when they in fact executed in background.
And QueryBrowser now always executes given queries in semi async mode .

The implementation is based on ClySemiAsyncQueryResult, new subclass of ClyAsyncQueryResult. And extra parameter #asyncResult in ClyAsyncQuery which is now part of comparison logic