### PR TITLE
disableBoldingMethods

### DIFF
--- a/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/specifyMethodItemNameOn.for..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyFullBrowser.class/instance/specifyMethodItemNameOn.for..st
@@ -1,6 +1,6 @@
 initialization
 specifyMethodItemNameOn: nameMorph for: methodItem
-	| definition highlightMainMethods |
+	| definition |
 	nameMorph contents: methodItem name.
 	
 	definition := methodItem	systemDefinition.
@@ -10,10 +10,7 @@ specifyMethodItemNameOn: nameMorph for: methodItem
 	self classSelection isMultipleSelected ifTrue: [
 		^nameMorph contents: (definition printFullNameOf: methodItem)].
 	
-	highlightMainMethods := methodGroupView showsItemsFromMultipleScope.
-	(self isClassSelected: definition definingClass) ifTrue: [ 	
-		highlightMainMethods ifTrue: [ nameMorph emphasis: TextEmphasis bold emphasisCode].
-		^self].
+	(self isClassSelected: definition definingClass) ifTrue: [ ^self].
 	
 	nameMorph emphasis: TextEmphasis italic emphasisCode.
 	nameMorph contents: (definition printFullNameOf: methodItem)


### PR DESCRIPTION
Now when inherited methdos  are visible in full browser the local methods are not highlighted as bold. 
Practice shows that it looks strange and not really helps