### PR TITLE
fixForQueryViewDialogAdoptation

### DIFF
--- a/Calypso-Browser.package/ClyQueryView.class/instance/adoptForDialog.st
+++ b/Calypso-Browser.package/ClyQueryView.class/instance/adoptForDialog.st
@@ -1,5 +1,5 @@
 controlling
 adoptForDialog
-	self itemCount < 10
+	(self areItemsLoaded and: [self itemCount < 10])
 		ifTrue: [ self height: 100 ]
-		ifFalse: [ self height: 300; enableFilter ].
+		ifFalse: [ self height: 300; enableFilter ]


### PR DESCRIPTION
fix query view adoptation for the dialog mode.
In case when it is background query and not built yet it should be full mode view