### PR TITLE
missingCommandsAndFixes

### DIFF
--- a/Calypso-Browser.package/ClyQueryView.class/instance/adoptForDialog.st
+++ b/Calypso-Browser.package/ClyQueryView.class/instance/adoptForDialog.st
@@ -2,4 +2,4 @@ controlling
 adoptForDialog
 	(self areItemsLoaded and: [self itemCount < 10])
 		ifTrue: [ self height: 100 ]
-		ifFalse: [ self height: 300; enableFilter ]
+		ifFalse: [ self height: 300; enableFilterUsing: ClyRegexPattern new]

--- a/Calypso-SystemPlugins-MethodDiffTool.package/ClyMethodDiffTool.class/instance/activationPriority.st
+++ b/Calypso-SystemPlugins-MethodDiffTool.package/ClyMethodDiffTool.class/instance/activationPriority.st
@@ -1,0 +1,3 @@
+accessing
+activationPriority
+	^0

--- a/Calypso-SystemQueries-Tests.package/ClyClassReferencesTests.class/instance/testDescriptionWhenSimpleClassBindingIsUsed.st
+++ b/Calypso-SystemQueries-Tests.package/ClyClassReferencesTests.class/instance/testDescriptionWhenSimpleClassBindingIsUsed.st
@@ -1,0 +1,6 @@
+tests
+testDescriptionWhenSimpleClassBindingIsUsed
+
+	query := ClyClassReferences to: Object binding.
+	
+	self assert: query description equals: 'references to Object'

--- a/Calypso-SystemQueries-Tests.package/ClyClassReferencesTests.class/properties.json
+++ b/Calypso-SystemQueries-Tests.package/ClyClassReferencesTests.class/properties.json
@@ -5,9 +5,7 @@
 	"classinstvars" : [ ],
 	"pools" : [ ],
 	"classvars" : [ ],
-	"instvars" : [
-		"var2"
-	],
+	"instvars" : [ ],
 	"name" : "ClyClassReferencesTests",
 	"type" : "normal"
 }

--- a/Calypso-SystemQueries.package/ClyMethodGroup.class/instance/convertToMethodTag..st
+++ b/Calypso-SystemQueries.package/ClyMethodGroup.class/instance/convertToMethodTag..st
@@ -1,0 +1,4 @@
+operations
+convertToMethodTag: aTagName
+
+	self methods do: [ :each | each tagWith: aTagName ]

--- a/Calypso-SystemQueries.package/ClyTaggedMethodGroup.class/instance/convertToMethodTag..st
+++ b/Calypso-SystemQueries.package/ClyTaggedMethodGroup.class/instance/convertToMethodTag..st
@@ -1,0 +1,4 @@
+operations
+convertToMethodTag: aTagName
+
+	self renameMethodTagTo: aTagName

--- a/Calypso-SystemQueries.package/ClyTaggedMethodGroup.class/instance/renameMethodTagTo..st
+++ b/Calypso-SystemQueries.package/ClyTaggedMethodGroup.class/instance/renameMethodTagTo..st
@@ -1,5 +1,6 @@
 operations
 renameMethodTagTo: newTag 
+	newTag = self tag ifTrue: [ ^self ].
 	
 	self methods do: [ :each |
 		each tagWith: newTag.

--- a/Calypso-SystemQueries.package/LiteralVariable.extension/instance/printAsConstantQueryItem.st
+++ b/Calypso-SystemQueries.package/LiteralVariable.extension/instance/printAsConstantQueryItem.st
@@ -1,0 +1,3 @@
+*Calypso-SystemQueries
+printAsConstantQueryItem
+	^key

--- a/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/class/shouldBeActivatedInContext..st
+++ b/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/class/shouldBeActivatedInContext..st
@@ -1,4 +1,3 @@
 testing
 shouldBeActivatedInContext: aBrowserContext
-	^aBrowserContext isClassSelected 
-		and: [aBrowserContext isMethodSelected not]
+	^aBrowserContext isClassSelected

--- a/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/class/tabOrder.st
+++ b/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/class/tabOrder.st
@@ -1,3 +1,3 @@
 accessing
 tabOrder
-	^ ClyClassDefinitionEditorTool tabOrder + 1
+	^ 1000

--- a/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/activationPriority.st
+++ b/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/activationPriority.st
@@ -4,4 +4,4 @@ activationPriority
 	Instead when user select class creation tool should not be activated"
 	^browser methodGroupSelection isEmpty 
 		ifTrue: [ 0]
-		ifFalse: [ super activationPriority ]
+		ifFalse: [ ClyClassDefinitionEditorTool tabOrder + 1 ]

--- a/Calypso-SystemTools-Core.package/ClyMethodTagsAndPackageEditor.class/instance/requestPackage.st
+++ b/Calypso-SystemTools-Core.package/ClyMethodTagsAndPackageEditor.class/instance/requestPackage.st
@@ -2,7 +2,6 @@ operations
 requestPackage
 
 	| extendingPackage |
-	extendingPackage := ownerTool browser searchDialog 
-		requestSingleObject: 'Choose package for method' from: ClyAllPackages sorted.
+	extendingPackage := ownerTool context requestSinglePackage: 'Choose package for method'.
 		
 	ownerTool extendingPackage: extendingPackage

--- a/Calypso-SystemTools-Core.package/ClyMethodTagsAndPackageEditor.class/instance/requestTag.st
+++ b/Calypso-SystemTools-Core.package/ClyMethodTagsAndPackageEditor.class/instance/requestTag.st
@@ -1,8 +1,12 @@
 operations
 requestTag
 
-	| selectedTag |
-	selectedTag := self ownerTool browser createCommandContext 
-		requestSingleMethodTag: 'New protocol name'.
+	| selectedTag existingTag |
+	existingTag := ownerTool methodTags 
+		ifEmpty: [ '' ] ifNotEmpty: [ :tags | tags anyOne ].
+
+	selectedTag := self ownerTool context
+		requestSingleMethodTag: 'New protocol name' suggesting: existingTag.
+	selectedTag = existingTag ifTrue: [ ^CmdCommandAborted signal ].
 	
 	ownerTool methodTags: { selectedTag asSymbol }

--- a/Calypso-SystemTools-Core.package/ClySystemBrowserContext.class/instance/requestSingleMethodTag..st
+++ b/Calypso-SystemTools-Core.package/ClySystemBrowserContext.class/instance/requestSingleMethodTag..st
@@ -1,20 +1,3 @@
 user requests
 requestSingleMethodTag: queryTitle
-	| knownTags ui selectedTag |
-	knownTags := (SystemNavigation default allExistingProtocolsFor: true)
-		reject: [ :each | each beginsWith: '*' ].
-	knownTags := knownTags asSortedCollection: [ :a :b | a asLowercase < b asLowercase ].	
-	ui := ListDialogWindow new
-		getList: [ :r | knownTags select: [ :e | r search: e ] ];
-		displayBlock: [ :e | e ];
-		initialAnswer: '';
-		acceptNewEntry: true;
-		title: queryTitle;
-		yourself.
-	selectedTag := ui chooseFromOwner: tool.
-	selectedTag isEmptyOrNil ifTrue: [ CmdCommandAborted signal].
-	(selectedTag beginsWith: '*') ifTrue: [ 
-		self inform: 'Star is forbidden for protocol name. You can specify package in method editor using status bar checkbox'.
-		^CmdCommandAborted signal].
-	
-	^selectedTag
+	^self requestSingleMethodTag: queryTitle suggesting: ''

--- a/Calypso-SystemTools-Core.package/ClySystemBrowserContext.class/instance/requestSingleMethodTag.suggesting..st
+++ b/Calypso-SystemTools-Core.package/ClySystemBrowserContext.class/instance/requestSingleMethodTag.suggesting..st
@@ -1,0 +1,20 @@
+user requests
+requestSingleMethodTag: queryTitle suggesting: suggestedTag
+	| knownTags ui selectedTag |
+	knownTags := (SystemNavigation default allExistingProtocolsFor: true)
+		reject: [ :each | each beginsWith: '*' ].
+	knownTags := knownTags asSortedCollection: [ :a :b | a asLowercase < b asLowercase ].	
+	ui := ListDialogWindow new
+		getList: [ :r | knownTags select: [ :e | r search: e ] ];
+		displayBlock: [ :e | e ];
+		initialAnswer: suggestedTag;
+		acceptNewEntry: true;
+		title: queryTitle;
+		yourself.
+	selectedTag := ui chooseFromOwner: tool.
+	selectedTag isEmptyOrNil ifTrue: [ CmdCommandAborted signal].
+	(selectedTag beginsWith: '*') ifTrue: [ 
+		self inform: 'Star is forbidden for protocol name. You can specify package in method editor using status bar checkbox'.
+		^CmdCommandAborted signal].
+	
+	^selectedTag asSymbol

--- a/Calypso-SystemTools-FullBrowser.package/ClyBrowser.extension/instance/browseClassNamed..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyBrowser.extension/instance/browseClassNamed..st
@@ -1,9 +1,11 @@
 *Calypso-SystemTools-FullBrowser
 browseClassNamed: aString
 	
-	| classBinding |
+	| classBinding classToBrowse |
 	classBinding := self system bindingOf: aString.
 	classBinding ifNil: [ ^self ].
+	classToBrowse := classBinding value.
+	classToBrowse isClassOrTrait ifFalse: [ classToBrowse := classToBrowse class ].
 	
 	self spawnBrowser: ClyFullBrowser withState: [ :browser |
-		browser selectClass: classBinding value]
+		browser selectClass: classToBrowse]

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/README.md
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/README.md
@@ -1,0 +1,7 @@
+I am a command to convert given method groups to method tag.
+I perform kind of "Move to protocol" operation for all contained methods
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	tagName:		<Symbol>

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/canBeExecutedInContext..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/canBeExecutedInContext..st
@@ -1,0 +1,3 @@
+testing
+canBeExecutedInContext: aToolContext
+	^aToolContext isMethodTagSelected not

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/defaultMenuItemName.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/defaultMenuItemName.st
@@ -1,0 +1,4 @@
+accessing
+defaultMenuItemName
+
+	^'Move to protocol'

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/fullBrowserContextMenuActivation.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/fullBrowserContextMenuActivation.st
@@ -1,0 +1,5 @@
+activation
+fullBrowserContextMenuActivation
+	<classAnnotation>
+	
+	^CmdContextMenuCommandActivation byRootGroupItemFor: ClyMethodGroupContextOfFullBrowser 

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/execute.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/execute.st
@@ -1,0 +1,4 @@
+execution
+execute
+	
+	methodGroups do: [ :each | each convertToMethodTag: tagName]

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/prepareFullExecutionInContext..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/prepareFullExecutionInContext..st
@@ -1,0 +1,5 @@
+execution
+prepareFullExecutionInContext: aToolContext
+	super prepareFullExecutionInContext: aToolContext.
+	
+	tagName := aToolContext requestSingleMethodTag: 'New protocol name'

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/tagName..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/tagName..st
@@ -1,0 +1,3 @@
+accessing
+tagName: anObject
+	tagName := anObject

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/tagName.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/instance/tagName.st
@@ -1,0 +1,3 @@
+accessing
+tagName
+	^ tagName

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/properties.json
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "DenisKudryashov 2/28/2018 11:04",
+	"super" : "ClyMethodGroupCommand",
+	"category" : "Calypso-SystemTools-FullBrowser-Commands-MethodGroups",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"tagName"
+	],
+	"name" : "ClyConvertMethodGroupToTagCommand",
+	"type" : "normal"
+}

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/README.md
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/README.md
@@ -1,0 +1,6 @@
+I am a command to move all methods of given method groups to another package.
+
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	package:		<RPackage>

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/defaultMenuItemName.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/defaultMenuItemName.st
@@ -1,0 +1,4 @@
+accessing
+defaultMenuItemName
+
+	^'Move to package'

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/fullBrowserContextMenuActivation.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/fullBrowserContextMenuActivation.st
@@ -1,0 +1,5 @@
+activation
+fullBrowserContextMenuActivation
+	<classAnnotation>
+	
+	^CmdContextMenuCommandActivation byRootGroupItemFor: ClyMethodGroupContextOfFullBrowser 

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/fullBrowserDragAndDropActivation.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/fullBrowserDragAndDropActivation.st
@@ -1,0 +1,7 @@
+activation
+fullBrowserDragAndDropActivation
+	<classAnnotation>
+	
+	^CmdDragAndDropCommandActivation 
+		for: ClyMethodGroup asCalypsoItemContext 
+		toDropIn: RPackage asCalypsoItemContext

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/execute.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/execute.st
@@ -1,0 +1,7 @@
+execution
+execute
+	
+	| repackagingCommand |
+	methodGroups do: [ :each | 
+		repackagingCommand := SycMoveMethodsToPackageCommand for: each methods to: package.
+		repackagingCommand execute]

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/package..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/package..st
@@ -1,0 +1,3 @@
+accessing
+package: anObject
+	package := anObject

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/package.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/package.st
@@ -1,0 +1,3 @@
+accessing
+package
+	^ package

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/prepareExecutionInDropContext..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/prepareExecutionInDropContext..st
@@ -1,0 +1,4 @@
+execution
+prepareExecutionInDropContext: aToolContext
+	super prepareExecutionInDropContext: aToolContext.
+	package := aToolContext lastSelectedPackage

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/prepareFullExecutionInContext..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/instance/prepareFullExecutionInContext..st
@@ -1,0 +1,5 @@
+execution
+prepareFullExecutionInContext: aToolContext
+	super prepareFullExecutionInContext: aToolContext.
+	
+	package := aToolContext requestSinglePackage: 'Choose package'

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/properties.json
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "DenisKudryashov 2/28/2018 11:05",
+	"super" : "ClyMethodGroupCommand",
+	"category" : "Calypso-SystemTools-FullBrowser-Commands-MethodGroups",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"package"
+	],
+	"name" : "ClyMoveMethodGroupsToPackageCommand",
+	"type" : "normal"
+}

--- a/Calypso-SystemTools-FullBrowser.package/ClyRenameMethodTagCommand.class/instance/prepareFullExecutionInContext..st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyRenameMethodTagCommand.class/instance/prepareFullExecutionInContext..st
@@ -3,11 +3,6 @@ prepareFullExecutionInContext: aToolContext
 	super prepareFullExecutionInContext: aToolContext.
 	
 	methodGroup := aToolContext lastSelectedMethodGroup.
-	newName := UIManager default 
-		request: 'New name of protocol' 
-		initialAnswer: methodGroup name 
-		title: 'Rename protocol'.
-	newName isEmptyOrNil | (newName = methodGroup name) ifTrue: [ CmdCommandAborted signal ].
-	(newName beginsWith: '*') ifTrue: [ 
-		self inform: 'Star is forbidden for protocol name. You can move methods to package using context menu command or drag and drop operation'.
-		^CmdCommandAborted signal].
+	newName := aToolContext 
+		requestSingleMethodTag: 'New name of protocol' suggesting: methodGroup name.
+	newName = methodGroup name ifTrue: [ CmdCommandAborted signal ]

--- a/Calypso-SystemTools-QueryBrowser.package/ClyBrowser.extension/instance/browseImplementorsOf..st
+++ b/Calypso-SystemTools-QueryBrowser.package/ClyBrowser.extension/instance/browseImplementorsOf..st
@@ -1,4 +1,12 @@
 *Calypso-SystemTools-QueryBrowser
 browseImplementorsOf: aSymbol
+	| classBinding classToBrowse |
+	aSymbol first isUppercase ifTrue: [ 
+		classBinding := self system bindingOf: aSymbol.
+		classBinding ifNotNil: [ 
+			classToBrowse := classBinding value.
+			classToBrowse isClassOrTrait ifFalse: [ classToBrowse := classToBrowse class ].
+			^self spawnBrowser: ClyFullBrowser withState: [ :browser | 
+				browser selectClass: classToBrowse]]].
 	
 	self spawnQueryBrowserOn: (ClyMessageImplementors of: aSymbol)


### PR DESCRIPTION
- Fix cmd+m to analyze given selector when it is uppercased.
- Fix to browse Smalltalk like globals form text editor- Fix class references query description when constant bindings are used as class query- MethodCreationTool is always present when classes are selected.
It placed after method editor when method is selected.
- MethodDiffTool is with lower activation priority. So it is never selected automatically- Menu item to move method group to package- Menu item to move method group to protocol - Regex filter for all search dialogs (like in package filter in full browser)