### PR TITLE
Bugs fixes and improvements

### DIFF
--- a/Calypso-Browser.package/ClyQueryView.class/instance/updateSelection.st
+++ b/Calypso-Browser.package/ClyQueryView.class/instance/updateSelection.st
@@ -5,7 +5,8 @@ updateSelection
 	"in some conditions table returnes bad index 0 which should not happens normaly.
 	Following select protects from this case"
 	selectedItems := table selectedRowIndexes 
-		select: [ :i | i > 0 ] thenCollect: [:each | self itemAt: each].
+		select: [ :i | i between: 1 and: self dataSource numberOfRows ] 
+		thenCollect: [:each | self itemAt: each].
 	selection := self newSelectionWith: selectedItems.
 
 	shouldRestoreSelection ifTrue: [ 

--- a/Calypso-Browser.package/ClyStatusBar.class/instance/defaultColor.st
+++ b/Calypso-Browser.package/ClyStatusBar.class/instance/defaultColor.st
@@ -1,3 +1,0 @@
-initialization
-defaultColor
-	^Color transparent

--- a/Calypso-Browser.package/ClyStatusBar.class/properties.json
+++ b/Calypso-Browser.package/ClyStatusBar.class/properties.json
@@ -1,6 +1,6 @@
 {
 	"commentStamp" : "DenisKudryashov 2/22/2018 14:30",
-	"super" : "Morph",
+	"super" : "PanelMorph",
 	"category" : "Calypso-Browser-UI",
 	"classinstvars" : [ ],
 	"pools" : [ ],

--- a/Calypso-Browser.package/ClyToolbar.class/properties.json
+++ b/Calypso-Browser.package/ClyToolbar.class/properties.json
@@ -1,6 +1,6 @@
 {
 	"commentStamp" : "DenisKudryashov 2/22/2018 10:32",
-	"super" : "Morph",
+	"super" : "PanelMorph",
 	"category" : "Calypso-Browser-Toolbar",
 	"classinstvars" : [ ],
 	"pools" : [ ],

--- a/Calypso-Browser.package/Pharo3DarkTheme.extension/instance/calypsoFrozenItemColor.st
+++ b/Calypso-Browser.package/Pharo3DarkTheme.extension/instance/calypsoFrozenItemColor.st
@@ -1,3 +1,0 @@
-*Calypso-Browser
-calypsoFrozenItemColor
-	^Color cyan

--- a/Calypso-Browser.package/Pharo3DarkTheme.extension/properties.json
+++ b/Calypso-Browser.package/Pharo3DarkTheme.extension/properties.json
@@ -1,3 +1,0 @@
-{
-	"name" : "Pharo3DarkTheme"
-}

--- a/Calypso-Browser.package/UITheme.extension/instance/calypsoFrozenItemColor.st
+++ b/Calypso-Browser.package/UITheme.extension/instance/calypsoFrozenItemColor.st
@@ -1,3 +1,9 @@
 *Calypso-Browser
 calypsoFrozenItemColor
-	^Color blue muchDarker
+	"For Pharo 6 compatibilit reason it is not separate overrides in concrete theme classes.
+	But this trick still allows override this color on external themes. 
+	Idea to only cover default ones which are white and dark"
+	
+	^self backgroundColor = Color white 
+		ifTrue: [ Color blue muchDarker]
+		ifFalse: [ Color cyan ] 

--- a/Calypso-Browser.package/UITheme.extension/instance/calypsoFrozenItemColor.st
+++ b/Calypso-Browser.package/UITheme.extension/instance/calypsoFrozenItemColor.st
@@ -4,6 +4,6 @@ calypsoFrozenItemColor
 	But this trick still allows override this color on external themes. 
 	Idea to only cover default ones which are white and dark"
 	
-	^self backgroundColor = Color white 
+	^self backgroundColor lightness > 0.3
 		ifTrue: [ Color blue muchDarker]
 		ifFalse: [ Color cyan ] 

--- a/Calypso-SystemPlugins-Critic-Browser.package/ClyCriticDecorator.class/instance/adoptBrowserToolLayout.st
+++ b/Calypso-SystemPlugins-Critic-Browser.package/ClyCriticDecorator.class/instance/adoptBrowserToolLayout.st
@@ -1,7 +1,7 @@
 decoration
 adoptBrowserToolLayout
 
-	originalToolPanel := BorderedMorph new.
+	originalToolPanel := PanelMorph new.
 	originalToolPanel 
 		name: 'original tool elements';
 		color: Color transparent;		

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/isEnabled..st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/isEnabled..st
@@ -1,0 +1,5 @@
+settings
+isEnabled: aBoolean
+	aBoolean 
+		ifTrue: [ self enableMethodGroup ]
+		ifFalse: [ self disableMethodGroup ]

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/isEnabled.st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/isEnabled.st
@@ -1,0 +1,3 @@
+settings
+isEnabled
+	^self providesMethodGroupByDefault

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/providesMethodGroupByDefault.st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/providesMethodGroupByDefault.st
@@ -1,3 +1,3 @@
 accessing
 providesMethodGroupByDefault
-	^providesMethodGroupByDefault ifNil: [ true ]
+	^providesMethodGroupByDefault ifNil: [ false ]

--- a/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/settingsOn..st
+++ b/Calypso-SystemPlugins-Critic-Queries.package/ClyCriticEnvironmentPlugin.class/class/settingsOn..st
@@ -1,0 +1,8 @@
+settings
+settingsOn: aBuilder
+	<systemsettings>
+	(aBuilder setting: #isEnabled)
+		parent: #Calypso;
+		label: 'Show critiques method group?';
+		description: 'If true, there will be special method group which will analyze all methods of selected classes in the browser. Analysis is performed in the background and should not affect general performance of the system';
+		target: self

--- a/Calypso-SystemPlugins-Monticello-Browser.package/ClyCommitMCPackageCommand.class/instance/execute.st
+++ b/Calypso-SystemPlugins-Monticello-Browser.package/ClyCommitMCPackageCommand.class/instance/execute.st
@@ -1,14 +1,18 @@
 execution
 execute
-	| icePackages iceRepos mcPackages |
-	packages ifEmpty: [ ^IceRepositoriesBrowser open ].
+	| repoBrowser commitBrowser repos targetRepo |
+	repoBrowser := self class environment at: #IceTipRepositoriesBrowser ifAbsent: [ 
+		^ self inform: 'Iceberg 0.7 and higher is required'].
+	commitBrowser := self class environment at: #IceTipCommitBrowser ifAbsent: [ 
+		^ self inform: 'Iceberg 0.7 and higher is required'].
+	packages ifEmpty: [ ^repoBrowser new openWithSpec ].
 	
-	icePackages := packages select: [ :each | [each iceRepository. true] ifError: [false]].	
-	iceRepos := icePackages collect: [ :each | each iceRepository ] as: Set.
-	iceRepos do: [ :each | IceSynchronizeBrowser synchronize: each ].
-	
-	mcPackages := packages copyWithoutAll: icePackages.
-	mcPackages ifNotEmpty: [ 
-		Komitter openAndCommitToMonticelloWorkingCopiesFilteredBy: [ :workingCopy |
-			"simple #includes: not works here. Somehow packages are different" 
-			mcPackages anySatisfy: [ :each | each name = workingCopy package name]]]
+	repos := IceRepository registry select: [ :repo | 
+		packages anySatisfy: [:each | repo includesPackageNamed: each name ]].
+	repos ifEmpty: [ ^self inform: 'Selected packages does not managed by Iceberg'].
+	targetRepo := repos size = 1 ifTrue: [ repos first ] ifFalse: [ 
+		UIManager default 
+			chooseFrom: (repos collect: #name) values: repos title: 'Choose repository'].
+	targetRepo ifNil: [ ^self ]. 
+			
+	(commitBrowser onRepository: targetRepo) openWithSpec

--- a/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/applyChanges.st
+++ b/Calypso-SystemTools-Core.package/ClyMethodCreationTool.class/instance/applyChanges.st
@@ -17,6 +17,6 @@ applyChanges
 	self tagAndPackageEditingMethod: newMethod.
 	
 	self removeFromBrowser.
-	browser tabManager forgetSelectedTab: self.
+	browser tabManager desiredSelection: {ClyMethodCodeEditorTool}.
 	browser selectMethod: newMethod.
 	^true

--- a/Calypso-SystemTools-Core.package/SycCopyMethodNameToClypboardCommand.extension/class/methodContextMenuActivation.st
+++ b/Calypso-SystemTools-Core.package/SycCopyMethodNameToClypboardCommand.extension/class/methodContextMenuActivation.st
@@ -1,0 +1,5 @@
+*Calypso-SystemTools-Core
+methodContextMenuActivation
+	<classAnnotation>
+	
+	^CmdContextMenuCommandActivation byItemOf: CmdExtraMenuGroup for: ClyMethod asCalypsoItemContext

--- a/Calypso-SystemTools-Core.package/SycCopyMethodNameToClypboardCommand.extension/class/methodTabIconActivation.st
+++ b/Calypso-SystemTools-Core.package/SycCopyMethodNameToClypboardCommand.extension/class/methodTabIconActivation.st
@@ -1,0 +1,5 @@
+*Calypso-SystemTools-Core
+methodTabIconActivation
+	<classAnnotation>
+	
+	^ClyBrowserTabCommandActivation for: ClyMethod asCalypsoItemContext

--- a/Calypso-SystemTools-Core.package/SycCopyMethodNameToClypboardCommand.extension/properties.json
+++ b/Calypso-SystemTools-Core.package/SycCopyMethodNameToClypboardCommand.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "SycCopyMethodNameToClypboardCommand"
+}

--- a/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/fullBrowserContextMenuActivation.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyConvertMethodGroupToTagCommand.class/class/fullBrowserContextMenuActivation.st
@@ -2,4 +2,4 @@ activation
 fullBrowserContextMenuActivation
 	<classAnnotation>
 	
-	^CmdContextMenuCommandActivation byRootGroupItemFor: ClyMethodGroupContextOfFullBrowser 
+	^CmdContextMenuCommandActivation byRootGroupItemFor: ClyMethodGroup asCalypsoItemContext 

--- a/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/fullBrowserContextMenuActivation.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyMoveMethodGroupsToPackageCommand.class/class/fullBrowserContextMenuActivation.st
@@ -2,4 +2,4 @@ activation
 fullBrowserContextMenuActivation
 	<classAnnotation>
 	
-	^CmdContextMenuCommandActivation byRootGroupItemFor: ClyMethodGroupContextOfFullBrowser 
+	^CmdContextMenuCommandActivation byRootGroupItemFor: ClyMethodGroup asCalypsoItemContext 

--- a/Calypso-SystemTools-FullBrowser.package/ClyTextEditor.extension/instance/browseIt.st
+++ b/Calypso-SystemTools-FullBrowser.package/ClyTextEditor.extension/instance/browseIt.st
@@ -1,9 +1,4 @@
 *Calypso-SystemTools-FullBrowser
 browseIt
-	| className |
 	self lineSelectAndEmptyCheck: [^ self].
-	
-	className := self findClassFromAST.
-	className isEmptyOrNil ifTrue: [ textArea flash. ^self ]. 
-	
-	self browser browseClassNamed: className
+	self browser browseClassNamed: (self selection string copyWithoutAll: CharacterSet crlf) trimBoth 


### PR DESCRIPTION
- Copy method name to clipboard command. It is very usefull for any bug reports. It is added as tab icon and to extra context menu group - critiques method group is disabled by default. It can be enabled in settings browser- #225 fixed- tab selection fix- commit command is adopted for latest iceberg. Kommitter logic is removed.- fix dark theme problem in pharo 7 #247- fix for browser updating after theme changes