### PR TITLE
Selecting a package and right-clicking in the empty space caused Exception

### DIFF
--- a/Calypso-SystemPlugins-SUnit-Browser.package/ClyBrowseCoveringTestCaseCommand.class/class/canBeExecutedInContext..st
+++ b/Calypso-SystemPlugins-SUnit-Browser.package/ClyBrowseCoveringTestCaseCommand.class/class/canBeExecutedInContext..st
@@ -1,5 +1,7 @@
 testing
 canBeExecutedInContext: aBrowserContext
 	(super canBeExecutedInContext: aBrowserContext) ifFalse: [ ^false ].
-	
-	^ aBrowserContext lastSelectedItem hasProperty: ClyTestedClassProperty
+
+	^ aBrowserContext hasSelectedItems
+		ifTrue: [ aBrowserContext lastSelectedItem hasProperty: ClyTestedClassProperty ]
+		ifFalse: [ false ]


### PR DESCRIPTION


Don't assume an item is selected but use >>#hasSelectedItems to see if there is an item.