### PR TITLE
categorizationOfClassSideMethodFix/#367

### DIFF
--- a/src/Calypso-SystemTools-FullBrowser/ClyMoveMethodsToGroupCommand.class.st
+++ b/src/Calypso-SystemTools-FullBrowser/ClyMoveMethodsToGroupCommand.class.st
@@ -76,6 +76,7 @@ ClyMoveMethodsToGroupCommand >> prepareExecutionInDropContext: aToolContext [
 	super prepareExecutionInDropContext: aToolContext.
 	methodGroup := aToolContext lastSelectedMethodGroup.
 	selectedClasses := aToolContext selectedClasses. 
+	selectedClasses := selectedClasses collect: [:each | aToolContext currentMetaLevelOf: each].
 	targetClass := selectedClasses size > 1 
 		ifTrue: [ aToolContext 
 			requestSingleClass: 'In what class you want to move method?' from: selectedClasses ]


### PR DESCRIPTION
Fix adds extra step to choose current side of class from selectedClasses during command preparation. Generally selected classes should return classes considering current meta leve of browser. But it was not done yet. It could affect remote scenario and probably some other functions. So it is for future. Not for this issue.