### PR TITLE
betterDebugTestCommand/400

### DIFF
--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestCommand.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyDebugTestCommand.class.st
@@ -36,7 +36,6 @@ ClyDebugTestCommand >> runTest: testSelector of: testClass [
 	| breakpoint |
 	breakpoint := Breakpoint new
 		node: (testClass lookupSelector: testSelector) ast;
-		once;
 		install.
 	[super runTest: testSelector of: testClass] ensure: [ breakpoint remove ]
 ]

--- a/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
+++ b/src/Calypso-SystemPlugins-SUnit-Browser/ClyTestSetUpEditorTool.class.st
@@ -13,7 +13,7 @@ Class {
 	#instVars : [
 		'testClass'
 	],
-	#category : 'Calypso-SystemPlugins-SUnit-Browser'
+	#category : #'Calypso-SystemPlugins-SUnit-Browser'
 }
 
 { #category : #activation }


### PR DESCRIPTION
Avoid break once in debug test command because it is badly supported in debugger